### PR TITLE
Data structure fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ les saisons, les épisodes, etc. L'accès se fait via l'instance `FirebaseFirest
   - seasons/{id} : Documents des saisons, contenant des références aux épisodes.
   - episodes/{id} : Documents des épisodes, contenant des références aux personnages.
 
+### CRUD (Create, Read, Update, Delete)
 - **Create**
 ```dart
 // Ajouter un document avec un ID auto-généré

--- a/lib/apps/app_simpson.dart
+++ b/lib/apps/app_simpson.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:simpsons_park/pages/tabs/newspapers_tab.dart';
 import 'package:simpsons_park/widgets/drawer/drawer_custom.dart';
 import 'package:simpsons_park/pages/tabs/characters_tab.dart';
 import 'package:simpsons_park/pages/tabs/seasons_tab.dart';
@@ -16,8 +17,9 @@ class _AppSimpsonState extends State<AppSimpson> {
   String title = 'Simpsons Park 2.0';
 
   static const List<Widget> _pagesOptions = <Widget>[
-    ChatactersTab(),
+    CharactersTab(),
     SeasonsTab(),
+    NewspapersTab()
   ];
 
   void _onItemTapped(int index) {
@@ -46,6 +48,12 @@ class _AppSimpsonState extends State<AppSimpson> {
           BottomNavigationBarItem(
               icon: Icon(Icons.tv),
               label: 'Saisons'
+          ),
+
+          // == Liste des Dossiers
+          BottomNavigationBarItem(
+              icon: Icon(Icons.folder),
+              label: 'Dossiers'
           ),
 
         ],

--- a/lib/models/character_model.dart
+++ b/lib/models/character_model.dart
@@ -7,6 +7,7 @@ class Character {
   final String pseudo;
   final String imageUrl;
   final String history;
+  final List<String> searchInitials;
 
   Character({
     required this.id,
@@ -15,6 +16,7 @@ class Character {
     required this.pseudo,
     required this.imageUrl,
     required this.history,
+    required this.searchInitials,
   });
 
   factory Character.fromFirestore(DocumentSnapshot doc) {
@@ -26,6 +28,7 @@ class Character {
       pseudo: data['pseudo'] as String? ?? '',
       imageUrl: data['imageUrl'] as String? ?? '',
       history: data['history'] as String? ?? '',
+      searchInitials: List<String>.from(data['searchInitials'] as List<dynamic>? ?? []),
     );
   }
 
@@ -37,16 +40,23 @@ class Character {
       pseudo: json['pseudo'] as String? ?? '',
       imageUrl: json['imageUrl'] as String? ?? '',
       history: json['history'] as String? ?? '',
+      searchInitials: List<String>.from(json['searchInitials'] as List<dynamic>? ?? []),
     );
   }
 
   Map<String, dynamic> toJson() {
+    List<String> initials = [];
+    if (firstName.isNotEmpty) initials.add(firstName[0].toUpperCase());
+    if (lastName.isNotEmpty) initials.add(lastName[0].toUpperCase());
+    if (pseudo.isNotEmpty) initials.add(pseudo[0].toUpperCase());
+    initials = initials.toSet().toList();
     return {
       'firstName': firstName,
       'lastName': lastName,
       'pseudo': pseudo,
       'imageUrl': imageUrl,
       'history': history,
+      'searchInitials': initials.isNotEmpty ? initials : null,
     };
   }
 }

--- a/lib/models/newspaper_model.dart
+++ b/lib/models/newspaper_model.dart
@@ -1,47 +1,43 @@
+// lib/models/newspaper_model.dart
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Newspaper {
-  final String id;
+  final String? id;
   final String title;
   final String subtitle;
   final String body;
-  final String author;
+  final String? authorEmail;
+  final Timestamp createdAt;
 
   Newspaper({
-    required this.id,
+    this.id,
     required this.title,
     required this.subtitle,
     required this.body,
-    required this.author
+    this.authorEmail,
+    required this.createdAt,
   });
-
-  factory Newspaper.fromFirestore(DocumentSnapshot doc) {
-    Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
-    return Newspaper(
-      id: doc.id,
-      title: data['title'] as String? ?? '',
-      subtitle: data['subtitle'] as String? ?? '',
-      body: data['body'] as String? ?? '',
-      author: data['author'] as String? ?? '',
-    );
-  }
-
-  factory Newspaper.fromJson(Map<String, dynamic> json) {
-    return Newspaper(
-      id: json['id'] as String? ?? '',
-      title: json['title'] as String? ?? '',
-      subtitle: json['subtitle'] as String? ?? '',
-      body: json['body'] as String? ?? '',
-      author: json['author'] as String? ?? '',
-    );
-  }
 
   Map<String, dynamic> toJson() {
     return {
       'title': title,
       'subtitle': subtitle,
       'body': body,
-      'author': author
+      'author': authorEmail,
+      'createdAt': createdAt,
     };
+  }
+
+
+  factory Newspaper.fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data()!;
+    return Newspaper(
+      id: doc.id,
+      title: data['title'] as String,
+      subtitle: data['subtitle'] as String,
+      body: data['body'] as String,
+      authorEmail: data['authorEmail'] as String?,
+      createdAt: data['createdAt'] as Timestamp,
+    );
   }
 }

--- a/lib/models/newspaper_model.dart
+++ b/lib/models/newspaper_model.dart
@@ -6,7 +6,7 @@ class Newspaper {
   final String title;
   final String subtitle;
   final String body;
-  final String? authorEmail;
+  final String? author;
   final Timestamp createdAt;
 
   Newspaper({
@@ -14,7 +14,7 @@ class Newspaper {
     required this.title,
     required this.subtitle,
     required this.body,
-    this.authorEmail,
+    this.author,
     required this.createdAt,
   });
 
@@ -23,7 +23,7 @@ class Newspaper {
       'title': title,
       'subtitle': subtitle,
       'body': body,
-      'author': authorEmail,
+      'author': author,
       'createdAt': createdAt,
     };
   }
@@ -36,7 +36,7 @@ class Newspaper {
       title: data['title'] as String,
       subtitle: data['subtitle'] as String,
       body: data['body'] as String,
-      authorEmail: data['authorEmail'] as String?,
+      author: data['author'] as String?,
       createdAt: data['createdAt'] as Timestamp,
     );
   }

--- a/lib/models/season_model.dart
+++ b/lib/models/season_model.dart
@@ -3,33 +3,24 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 class Season {
   final String id;
   final int seasonNumber;
-  final String title;
-  final List<Map<String, dynamic>> episodeReferences; // Pour stocker [{episode: Ref, seasonNumber: X}, ...]
+  final int episodeCount;
 
   Season({
     required this.id,
     required this.seasonNumber,
-    required this.title,
-    required this.episodeReferences,
+    required this.episodeCount,
   });
 
-  factory Season.fromFirestore(DocumentSnapshot doc) {
-    Map<String, dynamic> data = doc.data()! as Map<String, dynamic>;
-    // Important: S'assurer que le cast est sûr.
-    List<Map<String, dynamic>> refs = [];
-    if (data['episodes'] != null) {
-      // Firestore retourne List<dynamic>, chaque élément doit être casté en Map<String, dynamic>
-      refs = List<Map<String, dynamic>>.from(
-          (data['episodes'] as List<dynamic>).map((item) => item as Map<String, dynamic>)
-      );
+  factory Season.fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    if (data == null) {
+      throw Exception("Les données de la saison ${doc.id} sont nulles!");
     }
 
     return Season(
       id: doc.id,
-      seasonNumber: data['seasonNumber'] as int,
-      title: data['title'] as String? ?? 'Saison ${data['seasonNumber']}',
-      episodeReferences: refs, // Stocker les maps contenant les références
+      seasonNumber: data['seasonNumber'] as int? ?? 0,
+      episodeCount: data['episodeCount'] as int? ?? 0,
     );
   }
 }
-

--- a/lib/pages/newspaper_detail_page.dart
+++ b/lib/pages/newspaper_detail_page.dart
@@ -101,7 +101,7 @@ class NewspaperDetailPage extends StatelessWidget {
                 const SizedBox(width: 4),
                 Expanded(
                   child: Text(
-                    article.author ?? 'Membre de la communauté d\'amin',
+                    article.author ?? 'Membre de la communauté d\'admin',
                     style: textTheme.bodySmall?.copyWith(
                       color: Colors.grey[700],
                     ),

--- a/lib/pages/newspaper_detail_page.dart
+++ b/lib/pages/newspaper_detail_page.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import '../../models/newspaper_model.dart';
+import 'package:share_plus/share_plus.dart';
+
+class NewspaperDetailPage extends StatelessWidget {
+  final Newspaper article;
+
+  const NewspaperDetailPage({super.key, required this.article});
+
+  // Méthode pour un vrai partage d'article
+  Future<void> _shareArticle(BuildContext context) async {
+    final String articleTitle = article.title;
+    final String shareText =
+        "J'ai lu cet article intéressant sur Simpsons Park : \"$articleTitle\"";
+    final String articleUrl =
+        "https://simpsonspark.example.com/articles/${article.id ?? articleTitle.replaceAll(' ', '-').toLowerCase()}";
+    final String subject = "Article : $articleTitle";
+    final box = context.findRenderObject() as RenderBox?;
+
+    try {
+      final ShareResult result = await SharePlus.instance.share(
+        ShareParams(subject: subject, uri: Uri.parse(articleUrl)),
+      );
+
+      if (result.status == ShareResultStatus.success) {
+        if (kDebugMode) {
+          print('Merci pour le partage!');
+        }
+      } else if (result.status == ShareResultStatus.dismissed) {
+        if (kDebugMode) {
+          print('Partage de "$articleTitle" annulé par l\'utilisateur.');
+        }
+      } else if (result.status == ShareResultStatus.unavailable) {
+        if (kDebugMode) {
+          print('Partage de "$articleTitle" non disponible.');
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Aucune application de partage disponible.'),
+          ),
+        );
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('Erreur lors du partage de "$articleTitle": $e');
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Erreur lors du partage.')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(article.title, overflow: TextOverflow.ellipsis),
+        elevation: 8.0,
+        shadowColor: Colors.black87,
+        actions: [
+          // Option: Mettre l'icône de partage dans l'AppBar
+          IconButton(
+            icon: const Icon(Icons.share),
+            onPressed: () => _shareArticle(context),
+            tooltip: 'Partager l\'article',
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              article.title,
+              style: textTheme.headlineMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: theme.colorScheme.onSurface,
+              ),
+            ),
+            const SizedBox(height: 8.0),
+
+            if (article.subtitle.isNotEmpty) ...[
+              Text(
+                article.subtitle,
+                style: textTheme.titleLarge?.copyWith(
+                  fontStyle: FontStyle.italic,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 16.0),
+            ],
+
+            Row(
+              children: [
+                Icon(Icons.person_outline, size: 16, color: Colors.grey[700]),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    article.author ?? 'Membre de la communauté d\'amin',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: Colors.grey[700],
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4.0),
+            Row(
+              children: [
+                Icon(
+                  Icons.calendar_today_outlined,
+                  size: 16,
+                  color: Colors.grey[700],
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  "Publié le ${article.createdAt.toDate().day}/${article.createdAt.toDate().month}/${article.createdAt.toDate().year}",
+                  style: textTheme.bodySmall?.copyWith(color: Colors.grey[700]),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12.0),
+            Divider(color: theme.dividerColor.withValues()),
+            const SizedBox(height: 16.0),
+
+            SelectableText(
+              article.body,
+              style: textTheme.bodyLarge?.copyWith(
+                height: 1.6,
+                fontSize: 16,
+                color: theme.colorScheme.onSurface.withValues(),
+              ),
+              textAlign: TextAlign.justify,
+            ),
+            const SizedBox(height: 24.0),
+
+            // Bouton de Partage
+            Center(
+              child: ElevatedButton.icon(
+                icon: const Icon(Icons.share),
+                label: const Text('Partager cet article'),
+                onPressed: () => _shareArticle(context),
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24,
+                    vertical: 12,
+                  ),
+                  textStyle: const TextStyle(fontSize: 16),
+                  backgroundColor: theme.colorScheme.secondary,
+                  foregroundColor: theme.colorScheme.onSecondary,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/tabs/admin/dashboard_overview_tab.dart
+++ b/lib/pages/tabs/admin/dashboard_overview_tab.dart
@@ -46,8 +46,8 @@ class _DashboardOverviewTabState extends State<DashboardOverviewTab> {
             // == Épisodes enregistrés
             const SizedBox(height: 16),
             _buildCountCard(
-              title: 'Épisodes Enregistrés',
-              countStream: _firestore.collection('episodes').snapshots(),
+              title: 'Épisodes Enregistrés (Total)',
+              countStream: _firestore.collectionGroup('episodes').snapshots(), // <-- MODIFICATION CLÉ
               icon: Icons.tv_outlined,
               color: Colors.green,
             ),

--- a/lib/pages/tabs/admin/news_tab.dart
+++ b/lib/pages/tabs/admin/news_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:simpsons_park/widgets/forms/admin/form_newspaper_widget.dart';
 
 class NewsTab extends StatefulWidget {
   const NewsTab({super.key});
@@ -10,6 +11,8 @@ class NewsTab extends StatefulWidget {
 class _NewsTabState extends State<NewsTab> {
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      body: FormNewspaperWidget(),
+    );
   }
 }

--- a/lib/pages/tabs/episode_detail_page.dart
+++ b/lib/pages/tabs/episode_detail_page.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:simpsons_park/models/episode_model.dart';
+import 'package:simpsons_park/models/character_model.dart';
+
+class EpisodeDetailPage extends StatefulWidget {
+  final Episode episode;
+
+  const EpisodeDetailPage({
+    super.key,
+    required this.episode,
+  });
+
+  @override
+  State<EpisodeDetailPage> createState() => _EpisodeDetailPageState();
+}
+
+class _EpisodeDetailPageState extends State<EpisodeDetailPage> {
+  List<Character>? _loadedCharacters;
+  bool _isLoadingCharacters = true;
+  String? _characterLoadError;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchCharacters();
+  }
+
+  Future<void> _fetchCharacters() async {
+    if (!mounted) return;
+    setState(() {
+      _isLoadingCharacters = true;
+      _characterLoadError = null;
+    });
+    try {
+      final characters = await widget.episode.getOrLoadCharacters(FirebaseFirestore.instance);
+      if (mounted) {
+        setState(() {
+          _loadedCharacters = characters;
+          _isLoadingCharacters = false;
+        });
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print("Erreur lors du chargement des personnages pour l'épisode ${widget.episode.id}: $e");
+      }
+      if (mounted) {
+        setState(() {
+          _characterLoadError = "Impossible de charger les personnages.";
+          _isLoadingCharacters = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final Episode episode = widget.episode;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(episode.title, overflow: TextOverflow.ellipsis),
+        elevation: 1.0,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            if (episode.imageUrl.isNotEmpty)
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8.0),
+                child: Image.network(
+                  episode.imageUrl,
+                  height: 200,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, error, stackTrace) {
+                    return Container(
+                      height: 200,
+                      color: Colors.grey[300],
+                      child: const Center(child: Icon(Icons.broken_image, size: 50)),
+                    );
+                  },
+                  loadingBuilder: (context, child, loadingProgress) {
+                    if (loadingProgress == null) return child;
+                    return Container(
+                      height: 200,
+                      color: Colors.grey[300],
+                      child: const Center(child: CircularProgressIndicator()),
+                    );
+                  },
+                ),
+              ),
+            if (episode.imageUrl.isNotEmpty) const SizedBox(height: 16.0),
+
+            // Titre de l'épisode
+            Text(
+              episode.title,
+              style: textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: theme.colorScheme.onSurface,
+              ),
+            ),
+            const SizedBox(height: 8.0),
+
+            Wrap(
+              spacing: 8.0,
+              runSpacing: 4.0,
+              children: <Widget>[
+                _buildInfoChip(context, Icons.tv_outlined, 'S${episode.seasonNumber.toString().padLeft(2, '0')} E${episode.episodeNumber.toString().padLeft(2, '0')}'),
+                if (episode.releaseDate.isNotEmpty)
+                  _buildInfoChip(context, Icons.calendar_today_outlined, episode.releaseDate), // La date est déjà un String formaté
+                if (episode.duration.isNotEmpty)
+                  _buildInfoChip(context, Icons.timer_outlined, '${episode.duration} min'),
+              ],
+            ),
+            const SizedBox(height: 16.0),
+
+            // Synopsis
+            Text(
+              "Synopsis :",
+              style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8.0),
+            SelectableText(
+              episode.description,
+              style: textTheme.bodyLarge?.copyWith(
+                height: 1.5, // Interligne
+                fontSize: 15, // Taille de police
+                color: theme.colorScheme.onSurface.withOpacity(0.80),
+              ),
+              textAlign: TextAlign.justify,
+            ),
+            const SizedBox(height: 20.0),
+
+            // Section Personnages
+            Text(
+              "Personnages présents :",
+              style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8.0),
+            _buildCharactersSection(),
+
+            const SizedBox(height: 24.0),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoChip(BuildContext context, IconData icon, String label) {
+    return Chip(
+      avatar: Icon(icon, size: 16, color: Theme.of(context).colorScheme.onSecondaryContainer),
+      label: Text(label, style: TextStyle(color: Theme.of(context).colorScheme.onSecondaryContainer)),
+      backgroundColor: Theme.of(context).colorScheme.secondaryContainer.withOpacity(0.7),
+      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2.0),
+    );
+  }
+
+  Widget _buildCharactersSection() {
+    if (_isLoadingCharacters) {
+      return const Center(child: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: CircularProgressIndicator(),
+      ));
+    }
+
+    if (_characterLoadError != null) {
+      return Center(child: Text(_characterLoadError!, style: TextStyle(color: Theme.of(context).colorScheme.error)));
+    }
+
+    if (_loadedCharacters == null || _loadedCharacters!.isEmpty) {
+      return const Text('Aucun personnage spécifique listé pour cet épisode.');
+    }
+
+    return Wrap(
+      spacing: 8.0,
+      runSpacing: 4.0,
+      children: _loadedCharacters!.map((character) {
+        String characterName = "${character.firstName} ${character.lastName}".trim();
+        if (characterName.isEmpty) {
+          characterName = character.pseudo.isNotEmpty ? character.pseudo : "Personnage inconnu";
+        }
+        return Chip(
+          avatar: character.imageUrl.isNotEmpty
+              ? CircleAvatar(
+            backgroundImage: NetworkImage(character.imageUrl),
+            onBackgroundImageError: (e,s) => const Icon(Icons.person, size: 18), // Fallback si l'image du perso ne charge pas
+          )
+              : const CircleAvatar(child: Icon(Icons.person_outline, size: 18)),
+          label: Text(characterName),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/pages/tabs/newspapers_tab.dart
+++ b/lib/pages/tabs/newspapers_tab.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../models/newspaper_model.dart';
+import '../newspaper_detail_page.dart';
+
+class NewspapersTab extends StatefulWidget {
+  const NewspapersTab({super.key});
+
+  @override
+  State<NewspapersTab> createState() => _NewspapersTabState();
+}
+
+class _NewspapersTabState extends State<NewspapersTab> {
+  Query _buildNewspapersQuery() {
+    return FirebaseFirestore.instance
+        .collection('newspapers')
+        .orderBy('createdAt', descending: true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(8.0, 8.0, 8.0, 12.0),
+              child: Text(
+                "Articles Récents",
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+            ),
+            Expanded(
+              child: StreamBuilder<QuerySnapshot>(
+                stream: _buildNewspapersQuery().snapshots(),
+                builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
+                  if (snapshot.hasError) {
+                    if (kDebugMode) {
+                      print("Erreur Firestore (NewspapersTab): ${snapshot.error}");
+                    }
+                    return const Center(
+                      child: Text('Impossible de charger les articles...'),
+                    );
+                  }
+
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                    return const Center(
+                      child: Text('Aucun article trouvé.'),
+                    );
+                  }
+
+                  return ListView.builder(
+                    itemCount: snapshot.data!.docs.length,
+                    itemBuilder: (context, index) {
+                      DocumentSnapshot document = snapshot.data!.docs[index];
+                      Newspaper article = Newspaper.fromFirestore(
+                          document as DocumentSnapshot<Map<String, dynamic>>);
+
+                      bool hasSubtitle = article.subtitle.isNotEmpty;
+
+                      return Card(
+                        margin: const EdgeInsets.symmetric(vertical: 6.0, horizontal: 4.0),
+                        elevation: 2.0,
+                        clipBehavior: Clip.antiAlias,
+                        child: ListTile(
+                          title: Text(
+                            article.title,
+                            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          subtitle: hasSubtitle
+                              ? Text(
+                            article.subtitle,
+                            maxLines: 3,
+                            overflow: TextOverflow.ellipsis,
+                          )
+                              : null,
+                          trailing: const Icon(Icons.arrow_forward),
+                          contentPadding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 16.0),
+                          onTap: () {
+                            if (kDebugMode) {
+                              print('Tapped on ${article.title} (ID: ${article.id})');
+                            }
+                            if (article.id != null) {
+
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => NewspaperDetailPage(article: article),
+                                ),
+                              );
+
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('Navigation vers l\'article : ${article.title}')),
+                              );
+                            } else {
+                              if (kDebugMode) {
+                                print('Erreur: ID de l\'article manquant.');
+                              }
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Erreur: Impossible d\'ouvrir cet article.')),
+                              );
+                            }
+                          },
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/tabs/seasons_tab.dart
+++ b/lib/pages/tabs/seasons_tab.dart
@@ -1,9 +1,10 @@
-// seasons_tab.dart
+// lib/pages/tabs/seasons_tab.dart
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:simpsons_park/models/season_model.dart'; // Ensure this path is correct
-import 'package:simpsons_park/models/episode_model.dart'; // Ensure this path is correct
+import 'package:simpsons_park/models/season_model.dart';
+import 'package:simpsons_park/models/episode_model.dart';
+import 'episode_detail_page.dart';
 
 class SeasonsTab extends StatefulWidget {
   const SeasonsTab({super.key});
@@ -15,149 +16,23 @@ class SeasonsTab extends StatefulWidget {
 class _SeasonsTabState extends State<SeasonsTab> {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
-  // Key: season.id (String), Value: List of Episodes
-  final Map<String, List<Episode>> _loadedEpisodes = {};
-
-  // Key: season.id (String), Value: bool (true if loading)
-  final Map<String, bool> _isLoadingEpisodes = {};
-
-  Future<void> _fetchEpisodesForSeason(Season season) async {
-    if (_loadedEpisodes.containsKey(season.id) ||
-        (_isLoadingEpisodes[season.id] == true)) {
-      return;
-    }
-
-    setState(() {
-      _isLoadingEpisodes[season.id] = true;
-    });
-
-    List<Episode> fetchedEpisodes = [];
-
-    try {
-      if (kDebugMode) {
-        print("Fetching episodes for season ID: ${season.id}");
-      }
-
-      // Utiliser directement season.episodeReferences si le modèle Season les contient déjà
-      // Sinon, récupérer le document season à nouveau si nécessaire.
-      // Le modèle Season actuel stocke episodeReferences, donc nous devrions les utiliser.
-      // DocumentSnapshot seasonDoc = await _firestore.collection('seasons').doc(season.id).get();
-      // if (!seasonDoc.exists || seasonDoc.data() == null) {
-      //   if (kDebugMode) {
-      //     print("Season document ${season.id} not found or has no data.");
-      //   }
-      //   setState(() {
-      //     _loadedEpisodes[season.id] = [];
-      //     _isLoadingEpisodes[season.id] = false;
-      //   });
-      //   return;
-      // }
-      // Map<String, dynamic> seasonData = seasonDoc.data()! as Map<String, dynamic>;
-      // List<dynamic>? episodeRefsArray = seasonData['episodes'] as List<dynamic>?;
-
-      // Utilisation des références stockées dans l'objet Season
-      List<Map<String, dynamic>>? episodeRefsArray = season.episodeReferences;
-
-      if (episodeRefsArray.isEmpty) {
-        if (kDebugMode) {
-          print("No episode references found in season object ${season.id}");
-        }
-        setState(() {
-          _loadedEpisodes[season.id] = [];
-          // _isLoadingEpisodes[season.id] = false; // Géré dans finally
-        });
-        // return; // Ne pas retourner ici pour que finally s'exécute
-      } else {
-        // Seulement si episodeRefsArray n'est pas null et pas vide
-        for (var episodeMapEntry in episodeRefsArray) {
-          // Le modèle Season stocke déjà des Map<String, dynamic>
-          // donc episodeMapEntry est déjà une Map<String, dynamic>.
-          // if (episodeMapEntry is Map<String, dynamic>) { // Plus nécessaire si le type est garanti par Season.episodeReferences
-          final DocumentReference? episodeRef =
-              episodeMapEntry['episode'] as DocumentReference?;
-
-          if (episodeRef != null) {
-            try {
-              final DocumentSnapshot episodeDoc = await episodeRef.get();
-              if (episodeDoc.exists) {
-                fetchedEpisodes.add(
-                  Episode.fromFirestore(
-                    episodeDoc as DocumentSnapshot<Map<String, dynamic>>,
-                  ),
-                );
-              } else {
-                if (kDebugMode) {
-                  print(
-                    "Episode document not found for ref: ${episodeRef.path}",
-                  );
-                }
-              }
-            } catch (e, stackTrace) {
-              if (kDebugMode) {
-                print(
-                  "Error fetching individual episode ${episodeRef.path}: $e",
-                );
-              }
-              if (kDebugMode) {
-                print("Stack trace: $stackTrace");
-              }
-            }
-          }
-          // }
-        }
-      }
-
-      // Optionnel: Trier les épisodes si l'ordre n'est pas garanti par l'array
-      fetchedEpisodes.sort(
-        (a, b) => a.episodeNumber.compareTo(b.episodeNumber),
-      );
-
-      if (kDebugMode) {
-        print(
-          "Fetched ${fetchedEpisodes.length} episodes for season ${season.id}",
-        );
-      }
-
-      // Vérifier si le widget est toujours monté avant d'appeler setState
-      if (mounted) {
-        setState(() {
-          _loadedEpisodes[season.id] = fetchedEpisodes;
-        });
-      }
-    } catch (e, stackTrace) {
-      if (kDebugMode) {
-        print("Error in _fetchEpisodesForSeason for season ${season.id}: $e");
-      }
-      if (kDebugMode) {
-        print("Stack trace: $stackTrace");
-      }
-      if (mounted) {
-        setState(() {
-          _loadedEpisodes[season.id] = []; // Marquer comme erreur ou vide
-        });
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isLoadingEpisodes[season.id] = false;
-        });
-      }
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<QuerySnapshot>(
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: _firestore
           .collection('seasons')
           .orderBy('seasonNumber')
           .snapshots(),
-      builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> seasonSnapshot) {
+      builder: (
+          BuildContext context,
+          AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>> seasonSnapshot,
+          ) {
         if (seasonSnapshot.hasError) {
-          return Center(
-            child: Text(
-              'Quelque chose s\'est mal passé avec les saisons: ${seasonSnapshot.error}',
-            ),
+          if (kDebugMode) {
+            print("Erreur Firestore (SeasonsTab - Saisons): ${seasonSnapshot.error}");
+          }
+          return const Center(
+            child: Text('Quelque chose s\'est mal passé avec les saisons.'),
           );
         }
 
@@ -179,8 +54,7 @@ class _SeasonsTabState extends State<SeasonsTab> {
             return Season(
               id: doc.id,
               seasonNumber: 0,
-              title: "Error: Invalid Season Data",
-              episodeReferences: [],
+              episodeCount: 0,
             );
           }
         }).toList();
@@ -189,88 +63,93 @@ class _SeasonsTabState extends State<SeasonsTab> {
           itemCount: seasons.length,
           itemBuilder: (context, index) {
             final Season season = seasons[index];
-            final bool isCurrentlyLoadingEpisodes =
-                _isLoadingEpisodes[season.id] ?? false;
-            final List<Episode>? episodesForThisSeason =
-                _loadedEpisodes[season.id];
 
             return ExpansionTile(
               key: PageStorageKey<String>(season.id),
-              // Clé pour sauvegarder l'état d'expansion
               title: Text(
-                season.title.isNotEmpty
-                    ? season.title
-                    : 'Saison ${season.seasonNumber}',
+                'Saison ${season.seasonNumber} - ${season.episodeCount} épisodes',
               ),
-              onExpansionChanged: (isExpanded) {
-                if (isExpanded &&
-                    episodesForThisSeason == null &&
-                    !isCurrentlyLoadingEpisodes) {
-                  // Modifié : !_loadedEpisodes.containsKey(season.id) -> episodesForThisSeason == null
-                  // pour refléter plus directement si les données sont chargées pour l'UI.
-                  _fetchEpisodesForSeason(season);
-                }
-              },
               children: <Widget>[
-                if (isCurrentlyLoadingEpisodes)
-                  const Padding(
-                    padding: EdgeInsets.all(16.0),
-                    child: Center(child: CircularProgressIndicator()),
-                  )
-                else if (episodesForThisSeason != null &&
-                    episodesForThisSeason.isNotEmpty)
-                  // Enveloppe le ListView.builder dans son propre PageStorageBucket
-                  PageStorage(
-                    bucket: PageStorageBucket(),
-                    // Crée un nouveau contexte de stockage pour ce sous-arbre
-                    child: ListView.builder(
-                      key: ValueKey('episodes_list_for_season_${season.id}'),
-                      // Clé unique pour ce ListView
-                      shrinkWrap: true,
-                      physics: const NeverScrollableScrollPhysics(),
-                      itemCount: episodesForThisSeason.length,
-                      itemBuilder: (context, episodeIndex) {
-                        final episode = episodesForThisSeason[episodeIndex];
+                StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                  stream: _firestore
+                      .collection('seasons')
+                      .doc(season.id)
+                      .collection('episodes')
+                      .orderBy('episodeNumber')
+                      .snapshots(),
+                  builder: (
+                      BuildContext context,
+                      AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>> episodeSnapshot,
+                      ) {
+                    if (episodeSnapshot.hasError) {
+                      if (kDebugMode) {
+                        print("Erreur Firestore (SeasonsTab - Episodes pour ${season.id}): ${episodeSnapshot.error}");
+                      }
+                      return const ListTile(title: Text('Erreur de chargement des épisodes.'));
+                    }
+
+                    if (episodeSnapshot.connectionState == ConnectionState.waiting) {
+                      return const Padding(
+                        padding: EdgeInsets.all(16.0),
+                        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+                      );
+                    }
+
+                    if (!episodeSnapshot.hasData || episodeSnapshot.data!.docs.isEmpty) {
+                      return const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 32.0, vertical: 16.0),
+                        child: Center(
+                          child: Text('Aucun épisode trouvé pour cette saison.'),
+                        ),
+                      );
+                    }
+
+                    // Lliste des ListTiles d'épisodes
+                    return Column(
+                      children: episodeSnapshot.data!.docs.map<Widget>((episodeDoc) {
+                        final Episode episode = Episode.fromFirestore(episodeDoc); // Utilise Episode.fromFirestore
                         return ListTile(
+                          key: ValueKey(episode.id),
                           title: Text(
-                            'E${episode.episodeNumber}: ${episode.title}',
+                            'E${episode.episodeNumber.toString().padLeft(2, '0')}: ${episode.title}',
                           ),
-                          leading: Image.network(episode.imageUrl),
+                          leading: episode.imageUrl.isNotEmpty
+                              ? Image.network(
+                            episode.imageUrl,
+                            width: 50,
+                            height: 50,
+                            fit: BoxFit.cover,
+                            errorBuilder: (context, error, stackTrace) {
+                              return const Icon(Icons.broken_image, size: 50);
+                            },
+                          )
+                              : const Icon(Icons.tv_sharp, size: 50),
                           subtitle: Text(
-                            "${episode.releaseDate} - ${episode.duration} min",
+                            "${episode.releaseDate} - ${episode.duration}",
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
                           ),
-                          trailing: const Icon(Icons.arrow_forward),
+                          trailing: const Icon(Icons.arrow_forward_ios, size: 16),
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: 32.0,
                             vertical: 8.0,
                           ),
                           onTap: () {
                             if (kDebugMode) {
-                              print('Tapped on ${episode.title}');
-                              // Exemple pour charger et afficher les personnages :
-                              // episode.getOrLoadCharacters(_firestore).then((characters) {
-                              //   print("Personnages pour ${episode.title}:");
-                              //   for (var char in characters) {
-                              //     print("- ${char.name}"); // Supposant que Character a un champ 'name'
-                              //   }
-                              // });
+                              print('Tapped on episode: ${episode.title} (ID: ${episode.id})');
                             }
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => EpisodeDetailPage(episode: episode),
+                              ),
+                            );
                           },
                         );
-                      },
-                    ),
-                  )
-                else if (episodesForThisSeason != null &&
-                    episodesForThisSeason.isEmpty &&
-                    !isCurrentlyLoadingEpisodes)
-                  const Padding(
-                    padding: EdgeInsets.all(16.0),
-                    child: Center(
-                      child: Text('Aucun épisode trouvé pour cette saison.'),
-                    ),
-                  ),
+                      }).toList(),
+                    );
+                  },
+                ),
               ],
             );
           },

--- a/lib/widgets/forms/admin/form_newspaper_widget.dart
+++ b/lib/widgets/forms/admin/form_newspaper_widget.dart
@@ -111,7 +111,7 @@ class _FormNewspaperWidgetState extends State<FormNewspaperWidget> {
         child: ListView(
           children: <Widget>[
             Text(
-              'Qu',
+              'Ajouter un article\ndans le dossiers',
               style: theme.textTheme.headlineSmall?.copyWith(
                 fontWeight: FontWeight.bold,
                 color: colorScheme.onSurface,

--- a/lib/widgets/forms/admin/form_newspaper_widget.dart
+++ b/lib/widgets/forms/admin/form_newspaper_widget.dart
@@ -1,0 +1,217 @@
+// lib/widgets/form_newspaper_widget.dart
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+// Importer le modèle si tu l'as mis dans un fichier séparé
+// import '../models/newspaper_model.dart'; // Adapte le chemin si nécessaire
+
+class FormNewspaperWidget extends StatefulWidget {
+  const FormNewspaperWidget({super.key});
+
+  @override
+  State<FormNewspaperWidget> createState() => _FormNewspaperWidgetState();
+}
+
+class _FormNewspaperWidgetState extends State<FormNewspaperWidget> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _subtitleController = TextEditingController();
+  final _bodyController = TextEditingController();
+
+  bool _signWithEmail = false; // État de la checkbox
+  bool _isLoading =
+      false; // Pour l'indicateur de chargement lors de la soumission
+
+  User? get _currentUser => FirebaseAuth.instance.currentUser;
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _subtitleController.dispose();
+    _bodyController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submitForm() async {
+    if (!_formKey.currentState!.validate()) {
+      return; // Ne rien faire si le formulaire n'est pas valide
+    }
+
+    if (_isLoading) return; // Éviter les soumissions multiples
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    String? authorEmailValue;
+    if (_signWithEmail && _currentUser != null) {
+      authorEmailValue = _currentUser!.email;
+    }
+
+    // Création de l'objet ou du Map à envoyer à Firestore
+    Map<String, dynamic> newspaperData = {
+      'title': _titleController.text.trim(),
+      'subtitle': _subtitleController.text.trim(),
+      'body': _bodyController.text.trim(),
+      'authorEmail': authorEmailValue, // Peut être null
+      'createdAt': Timestamp.now(), // Date et heure actuelles
+    };
+
+    try {
+      await FirebaseFirestore.instance
+          .collection('newspapers')
+          .add(newspaperData);
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Article ${_titleController.text} ajouté avec succès !',
+            ),
+            backgroundColor: Colors.green,
+          ),
+        );
+
+        _formKey.currentState!.reset();
+        _titleController.clear();
+        _subtitleController.clear();
+        _bodyController.clear();
+        setState(() {
+          _signWithEmail = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Erreur lors de l\'ajout de l\'article : $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Form(
+        key: _formKey,
+        child: ListView(
+          children: <Widget>[
+            Text(
+              'Qu',
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: colorScheme.onSurface,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            TextFormField(
+              controller: _titleController,
+              decoration: const InputDecoration(
+                labelText: 'Titre de l\'article',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.title),
+              ),
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Veuillez entrer un titre.';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _subtitleController,
+              decoration: const InputDecoration(
+                labelText: 'Sous-titre (optionnel)',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.subtitles_outlined),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _bodyController,
+              decoration: const InputDecoration(
+                labelText: 'Contenu de l\'article',
+                border: OutlineInputBorder(),
+                alignLabelWithHint: true,
+                prefixIcon: Padding(
+                  padding: EdgeInsets.only(bottom: 217),
+                  child: Icon(Icons.article_outlined),
+                ),
+              ),
+              maxLines: 10,
+              keyboardType: TextInputType.multiline,
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Veuillez entrer le contenu de l\'article.';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            if (_currentUser != null)
+              CheckboxListTile(
+                title: Text(
+                  'Signer cet article avec mon email (${_currentUser!.email})',
+                ),
+                value: _signWithEmail,
+                onChanged: (bool? newValue) {
+                  setState(() {
+                    _signWithEmail = newValue ?? false;
+                  });
+                },
+                controlAffinity: ListTileControlAffinity.leading,
+                activeColor: colorScheme.primary,
+              )
+            else
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8.0),
+                child: Text(
+                  'Vous devez être connecté pour pouvoir signer l\'article.',
+                  style: TextStyle(color: theme.hintColor),
+                ),
+              ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              icon: _isLoading
+                  ? Container(
+                      width: 24,
+                      height: 24,
+                      padding: const EdgeInsets.all(2.0),
+                      child: CircularProgressIndicator(
+                        color: colorScheme.onPrimary,
+                        strokeWidth: 3,
+                      ),
+                    )
+                  : const Icon(Icons.add_circle_outline),
+              label: Text(
+                _isLoading ? 'Envoi en cours...' : 'Ajouter l\'article',
+              ),
+              onPressed: _isLoading ? null : _submitForm,
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                backgroundColor: colorScheme.primary,
+                foregroundColor: colorScheme.onPrimary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,13 @@ import Foundation
 import cloud_firestore
 import firebase_auth
 import firebase_core
+import path_provider_foundation
+import share_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -137,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -185,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.23.0"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -304,6 +328,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -312,6 +344,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.17"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -320,6 +400,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -336,6 +424,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: b2961506569e28948d75ec346c28775bb111986bb69dc6a20754a457e3d97fa0
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.0"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "1032d392bc5d2095a77447a805aa3f804d2ae6a4d5eef5e6ebb3bd94c1bc19ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -349,6 +453,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -397,6 +509,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -421,6 +573,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.13.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:
@@ -439,4 +607,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   firebase_auth: ^5.5.4
   cloud_firestore: ^5.6.8
   intl: ^0.20.2
+  share_plus: ^11.0.0
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,8 @@
 #include <cloud_firestore/cloud_firestore_plugin_c_api.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   CloudFirestorePluginCApiRegisterWithRegistrar(
@@ -17,4 +19,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,8 @@ list(APPEND FLUTTER_PLUGIN_LIST
   cloud_firestore
   firebase_auth
   firebase_core
+  share_plus
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
# FireStore
Reorganisation of the data structure in the Firestore
Now, the data structure for seasons collection is like the following:
```graphql
"seasons" season[]: [
   {
      "id": string,
      "seasonNumber": number,
      "episodesCount": number,
      "episodes": [
         {
            "id": string,
            "seasonNumber": number,
            "episodeNumber": number,
            "title": string,
            "imageUrl": string,
            "description": string,
            "duration": string,
            "releaseDate": string,
            "charactersRef" string[]
         },
      ]
   },
]
```

All the episodes subcollections are now available using the following syntaxe :
```dart
FirebaseFirestore.instance.collection('seasons').doc(season.id).collection('episodes').snapshots();
```

Such as a dynamic Stream, it can be used like the following

```dart
return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
      stream: _firestore.collection('seasons').orderBy('seasonNumber').snapshots(),
      builder:(BuildContext context,AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>> seasonSnapshot) { ... }
```

> [!WARNING]
> `charactersRef` is now defined like an Array<String> whose elements ( characterID) must be case-sensitive as follows
> ex : **Homer Simpson id's document** is **homer_simpson**